### PR TITLE
Feature/distinguish error logs

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -1,0 +1,27 @@
+CREATE TABLE grades
+(
+	id VARCHAR(25) NOT NULL
+		CONSTRAINT grades_pkey
+			PRIMARY KEY,
+	list VARCHAR(2048) NOT NULL
+)
+;
+
+CREATE UNIQUE INDEX grades_id_uindex
+	ON grades (id)
+;
+
+CREATE TABLE logs
+(
+	id SERIAL NOT NULL
+		CONSTRAINT logs_pkey
+			PRIMARY KEY,
+	log VARCHAR(20480) NOT NULL,
+	is_error BOOLEAN DEFAULT FALSE NOT NULL
+)
+;
+
+CREATE UNIQUE INDEX logs_id_uindex
+	ON logs (id)
+;
+

--- a/usosfetch/data_manager.py
+++ b/usosfetch/data_manager.py
@@ -7,7 +7,7 @@ import re
 GRADES_PREFIX = 'GRADES_'
 
 
-class DataManager:
+class GradesManager:
 
     _session = None
     _urls = None

--- a/usosfetch/executor.py
+++ b/usosfetch/executor.py
@@ -2,7 +2,7 @@ import requests
 import os
 import traceback
 from usosfetch.authorizer import Authorizer
-from usosfetch.data_manager import DataManager
+from usosfetch.data_manager import GradesManager
 from usosfetch.notifier import Notifier
 from usosfetch.logger import Logger
 
@@ -19,7 +19,7 @@ def main():
         with requests.Session() as session:
 
             authorizer = Authorizer(session)
-            data_manager = DataManager(session, logger)
+            data_manager = GradesManager(session, logger)
 
             authorizer.login(os.environ["USOS_USERNAME"], os.environ["USOS_PASSWORD"])
 

--- a/usosfetch/executor.py
+++ b/usosfetch/executor.py
@@ -12,8 +12,7 @@ def main():
     authorizer = None
 
     try:
-        logger.begin_session()
-
+        
         notifier = Notifier(os.environ['RECEIVER_EMAIL'], logger)
 
         with requests.Session() as session:

--- a/usosfetch/logger.py
+++ b/usosfetch/logger.py
@@ -10,18 +10,20 @@ ERROR = 'ERROR'
 class Logger:
 
     _log = {}
+    _is_error = False
+
+    def __init__(self):
+        self.log('Begin log session.')
 
     def _log_entry(self, severity, date, message):
         print(severity + ': ' + str(date) + ': ' + str(message))
         self._log[str(date)] = severity + ': ' + str(message)
 
-    def begin_session(self):
-        self._log_entry(LOG, datetime.now(), 'Begin log session.')
-
     def log(self, message):
         self._log_entry(LOG, datetime.now(), message)
 
     def error(self, message):
+        self._is_error = True
         self._log_entry(ERROR, datetime.now(), message)
 
     def save_to_database(self):
@@ -30,4 +32,4 @@ class Logger:
 
             row = json.dumps(self._log, sort_keys=True, indent=4, separators=(',', ': '))
 
-            cursor.execute("""INSERT INTO logs (log) VALUES (%s)""", (row,))
+            cursor.execute("""INSERT INTO logs (log, is_error) VALUES (%s, %s)""", (row, self._is_error))


### PR DESCRIPTION
Solves #8 
Added another field to logs, `is_error`, that is set to `true` if and only if there was at least one `error` logged (via `Logger.error`).
Also created the `database.sql` file with commands needed to set-up the postgres database from scratch (without ownerships).